### PR TITLE
[Fix] load matlabbatch

### DIFF
--- a/spm/__wrapper__/array.py
+++ b/spm/__wrapper__/array.py
@@ -1,10 +1,10 @@
+import numpy as np
+
 from .core import (
-    WrappedArray, 
+    WrappedArray,
     _ListishMixin
 )
 from .utils import _copy_if_needed
-
-import numpy as np
 
 
 class Array(_ListishMixin, WrappedArray):
@@ -178,7 +178,7 @@ class Array(_ListishMixin, WrappedArray):
         array : Array
             Converted array.
         """
-        from .cell import Cell # FIXME: avoid circular import
+        from .cell import Cell  # FIXME: avoid circular import
 
         if not isinstance(other, Cell):
             raise TypeError(f"Expected a {Cell} but got a {type(other)}")

--- a/spm/__wrapper__/cell.py
+++ b/spm/__wrapper__/cell.py
@@ -1,3 +1,4 @@
+import numpy as np
 from .core import (
     MatlabType,
     WrappedArray,
@@ -6,14 +7,12 @@ from .core import (
     _ListMixin,
 )
 from .utils import (
-    _empty_array, 
-    _copy_if_needed, 
-    _import_matlab, 
+    _empty_array,
+    _copy_if_needed,
+    _import_matlab,
     _matlab_array_types
 )
 global matlab
-
-import numpy as np
 
 
 class Cell(_ListMixin, WrappedArray):

--- a/spm/__wrapper__/core/delayed_types.py
+++ b/spm/__wrapper__/core/delayed_types.py
@@ -256,6 +256,7 @@ class AnyDelayedArray(AnyMatlabArray):
         self.as_struct[key] = value
         return self._finalize()  # Setter -> we can trigger finalize
 
+
 class WrappedDelayedArray(AnyDelayedArray):
     """
     Base class for future objects with known type.

--- a/spm/__wrapper__/core/mixin_types.py
+++ b/spm/__wrapper__/core/mixin_types.py
@@ -1,16 +1,17 @@
+from collections.abc import (
+    MutableSequence,
+    MutableMapping,
+    KeysView,
+    ValuesView,
+    ItemsView
+)
+import numpy as np
+
 from .base_types import MatlabType
 from .wrapped_types import WrappedArray
 from .delayed_types import AnyDelayedArray
 from ..utils import _matlab_array_types, _empty_array
 
-import numpy as np
-from collections.abc import (
-    MutableSequence, 
-    MutableMapping, 
-    KeysView, 
-    ValuesView, 
-    ItemsView
-)
 
 class _ListishMixin:
     """These methods are implemented in Cell and Array, but not Struct."""
@@ -81,7 +82,7 @@ class _SparseMixin:
         indices = np.asarray(dictobj['indices__'], dtype=np.long) - 1
         values = np.asarray(dictobj['values__'], dtype=dtype).ravel()
         return cls.from_coo(values, indices.T, size)
-    
+
 
 class _ListMixin(_ListishMixin, MutableSequence):
     """These methods are implemented in Cell, but not in Array or Struct."""
@@ -303,7 +304,6 @@ class _ListMixin(_ListishMixin, MutableSequence):
                 self.reverse()
 
 
-
 class _DictMixin(MutableMapping):
 
     # NOTE:
@@ -446,7 +446,7 @@ class _DictMixin(MutableMapping):
 
             parent = getattr(self, "_delayed_wrapper", self)
 
-            from ..struct import Struct # FIXME: circular imports
+            from ..struct import Struct  # FIXME: circular imports
             delayed = Struct(self.shape)
             opt = dict(
                 flags=['refs_ok', 'zerosize_ok', 'multi_index'],
@@ -527,7 +527,7 @@ class _DictMixin(MutableMapping):
                 item.setdefault(key, value)
 
     def update(self, other):
-        from ..struct import Struct # FIXME: circular imports
+        from ..struct import Struct  # FIXME: circular imports
         other = Struct.from_any(other)
         other = np.ndarray.view(other, np.ndarray)
         other = np.broadcast_to(other, self.shape)
@@ -542,7 +542,7 @@ class _DictMixin(MutableMapping):
                 item.update(other_elem)
 
     # --- helper ------------------------------------------------------
-    class deal: # FIXME: Removed dependency to Cell
+    class deal:  # FIXME: Removed dependency to Cell
         """
         Helper class to assign values into a specific field of a Struct array.
 
@@ -573,6 +573,5 @@ class _DictMixin(MutableMapping):
             return np.broadcast_to(self, shape)
 
         def to_cell(self):
-            from ..cell import Cell # FIXME: circular imports
+            from ..cell import Cell  # FIXME: circular imports
             return np.ndarray.view(self, Cell)
-

--- a/spm/__wrapper__/core/wrapped_types.py
+++ b/spm/__wrapper__/core/wrapped_types.py
@@ -1,6 +1,6 @@
 from .base_types import (
-    MatlabType, 
-    AnyMatlabArray, 
+    MatlabType,
+    AnyMatlabArray,
 )
 from .delayed_types import (
     AnyDelayedArray,
@@ -8,6 +8,7 @@ from .delayed_types import (
     DelayedStruct,
 )
 import numpy as np
+
 
 # ----------------------------------------------------------------------
 # WrappedArray
@@ -294,7 +295,7 @@ class WrappedArray(np.ndarray, AnyWrappedArray):
 
     def _return_delayed(self, index):
         from ..cell import Cell
-        from ..struct import Struct # FIXME: avoid circular import
+        from ..struct import Struct  # FIXME: avoid circular import
 
         if not isinstance(index, tuple):
             index = (index,)

--- a/spm/__wrapper__/matlab_class.py
+++ b/spm/__wrapper__/matlab_class.py
@@ -1,7 +1,8 @@
+import warnings
+import numpy as np
+
 from .core import MatlabType
 
-import numpy as np
-import warnings
 
 class MatlabClass(MatlabType):
     _subclasses = dict()
@@ -96,7 +97,7 @@ class MatlabClass(MatlabType):
             )
         except TypeError:
             pass
-        
+
         from .runtime import Runtime
 
         if not hasattr(self, '__endfn'):

--- a/spm/__wrapper__/matlab_function.py
+++ b/spm/__wrapper__/matlab_function.py
@@ -1,6 +1,7 @@
 from .core import MatlabType
 from .utils import _import_matlab
 
+
 class MatlabFunction(MatlabType):
     """
     Wrapper for matlab function handles.
@@ -19,7 +20,7 @@ class MatlabFunction(MatlabType):
         matlab = _import_matlab()
         if not isinstance(matlab_object, matlab.object):
             raise TypeError("Expected a matlab.object")
-        
+
         self._matlab_object = matlab_object
 
     def _as_runtime(self):

--- a/spm/__wrapper__/runtime.py
+++ b/spm/__wrapper__/runtime.py
@@ -33,7 +33,7 @@ class Runtime:
 
     @staticmethod
     def _process_argout(res):
-        return MatlabType.from_any(res)
+        return MatlabType._from_runtime(res)
 
     @staticmethod
     def _import_initialize():
@@ -57,7 +57,7 @@ class Runtime:
             # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             print(Runtime._help)
             raise e
-        
+
         # Make sure matlab is imported
         _import_matlab()
 
@@ -69,4 +69,3 @@ class Runtime:
     If the issue persists, please open an issue with the entire error
     message at https://github.com/spm/spm-python/issues.
     """
-

--- a/spm/__wrapper__/sparse_array.py
+++ b/spm/__wrapper__/sparse_array.py
@@ -1,5 +1,8 @@
+import warnings
+import numpy as np
+
 from .core import (
-    AnyWrappedArray, 
+    AnyWrappedArray,
     _SparseMixin
 )
 from .utils import (
@@ -8,8 +11,6 @@ from .utils import (
 )
 from .array import Array
 
-import numpy as np
-import warnings
 
 if sparse:
     class WrappedSparseArray(sparse.sparray, AnyWrappedArray):
@@ -205,4 +206,3 @@ else:
             obj = cls.from_shape(shape, dtype=dtype)
             obj[tuple(indices)] = values
             return obj
-

--- a/spm/__wrapper__/struct.py
+++ b/spm/__wrapper__/struct.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from .core import (
     WrappedArray,
     _DictMixin,
@@ -5,11 +7,9 @@ from .core import (
     DelayedStruct
 )
 from .utils import (
-    _copy_if_needed, 
+    _copy_if_needed,
     _empty_array
 )
-
-import numpy as np
 
 
 class Struct(_DictMixin, WrappedArray):
@@ -358,7 +358,7 @@ class Struct(_DictMixin, WrappedArray):
 
         raise ValueError(keys)
         return asdict
-    
+
     def _allkeys(self):
         # Return all keys present across all elements.
         # Keys are ordered by (1) element (2) within-element order
@@ -478,4 +478,3 @@ class Struct(_DictMixin, WrappedArray):
             return _DictMixin.__delitem__(self, key)
         except KeyError as e:
             raise AttributeError(str(e))
-

--- a/spm/__wrapper__/utils.py
+++ b/spm/__wrapper__/utils.py
@@ -7,9 +7,11 @@ try:
 except (ImportError, ModuleNotFoundError):
     sparse = None
 
+
 # ----------------------------------------------------------------------
 # Helpers
 # ----------------------------------------------------------------------
+
 
 # We'll complain later if the runtime is not instantiated
 def _import_matlab():
@@ -17,7 +19,7 @@ def _import_matlab():
         import matlab
     except (ImportError, ModuleNotFoundError):
         matlab = None
-    return matlab 
+    return matlab
 
 
 def _copy_if_needed(out, inp, copy=None) -> np.ndarray:


### PR DESCRIPTION
A somewhat recent change to the type system (from about ~2 weeks ago) had quite profoundly broken the conversion of objects from matlab to python. The fix is very short and simple (830af61a821b5394386963d2bc5225f4eabe55b2).

It's a bit annoying that this was not detected by our unit tests. I haven't thought too much about which tests should be added to cover this issue yet. The issue is that since the aforementioned change, dictionaries and lists are not treated exactly the same way depending on whether we know that we are converting mpython objects or not.

I've also made tiny stylistic changes to make my linter happy.