### PR TITLE
[Mnt] Runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,30 +9,45 @@ description = "Python bindings for the SPM software."
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [
-  {name = "Johan Medrano", email = "johan.medrano@ucl.ac.uk"}, 
-  {name = "Yael Balbastre", email = "y.balbastre@ucl.ac.yk"}]
-requires-python = ">=3.9,<3.13"
+  {name = "Johan Medrano", email = "johan.medrano@ucl.ac.uk"},
+  {name = "Yael Balbastre", email = "y.balbastre@ucl.ac.uk"}]
+requires-python = ">=3.6,<3.13"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+  "Programming Language :: Python :: 3.6",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "numpy", 
-    "mpython-core"
+    "mpython-core",
+    "spm-runtime-R2024b; python_version>='3.9' and python_version<'3.13'",
+    "spm-runtime-R2023a; python_version=='3.8'",
+    "spm-runtime-R2021b; python_version=='3.7'",
+    "spm-runtime-R2020b; python_version=='3.6'",
 ]
+
+[project.optional-dependencies]
+latest = ["spm-runtime"]
+R2024b = ["spm-runtime-R2024b"]
+R2024a = ["spm-runtime-R2024a"]
+R2023b = ["spm-runtime-R2023b"]
+R2023a = ["spm-runtime-R2023a"]
+R2022b = ["spm-runtime-R2022b"]
+R2022a = ["spm-runtime-R2022a"]
+R2021b = ["spm-runtime-R2021b"]
+R2021a = ["spm-runtime-R2021a"]
+R2020b = ["spm-runtime-R2020b"]
 
 [project.urls]
 Repository = "https://github.com/spm/spm-python"
 
 [tool.setuptools.packages]
 find = {}
-
-[tool.setuptools.package-data]
-spm = ["_spm/_spm.ctf"]
 
 [tool.setuptools.dynamic]
 version = {attr = "spm._version.__version__"}

--- a/spm/__init__.py
+++ b/spm/__init__.py
@@ -1,5 +1,4 @@
 from mpython import (
-    Runtime,
     MatlabClass,
     MatlabFunction,
     Cell,
@@ -7,6 +6,7 @@ from mpython import (
     Array,
     SparseArray,
 )
+from ._runtime import Runtime
 from ._version import __version__
 from .file_array import file_array
 from .gifti import gifti

--- a/spm/_runtime.py
+++ b/spm/_runtime.py
@@ -1,0 +1,23 @@
+from mpython.runtime import Runtime as RuntimeBase
+
+
+class Runtime(RuntimeBase):
+    """
+    Runtime specialization that imports the correct CTF.
+    """
+
+    @classmethod
+    def _import_runtime(cls):
+        import spm_runtime
+        return spm_runtime
+
+
+class RuntimeMixin:
+    """
+    Mixin that SPM classes must inherit so that they can call the
+    correct runtime.
+    """
+
+    @classmethod
+    def _runtime(cls):
+        return Runtime


### PR DESCRIPTION
This PR adds spm-runtime as a dependency and implements a specialized version of `mpython.Runtime` that imports the SPM runtime. 

I keep it as draft for now, as it needs concurrent changes in `mpython`, `mpython-core` and `spm-runtime`.

The `mpython` needs to make all SPM classes inherit from `spm._runtime.RuntimeMixin`.

### Linked PRs
- https://github.com/MPython-Package-Factory/mpython-core/pull/9